### PR TITLE
Remove virtio-rng-pci from the launch script

### DIFF
--- a/distros/launch-qemu.sh
+++ b/distros/launch-qemu.sh
@@ -29,7 +29,7 @@ usage() {
 	echo " -cdrom        CDROM image"
 	echo " -virtio       use virtio devices"
 	echo " -gdb          start gdbserver"
-	exit 1  
+	exit 1
 }
 
 add_opts() {
@@ -165,11 +165,6 @@ fi
 
 # start monitor on pty
 add_opts "-monitor pty"
-
-# add virtio ring
-if [ "$USE_VIRTIO" = "1" ]; then
-	add_opts "-device virtio-rng-pci,disable-legacy=on,iommu_platform=true"
-fi
 
 # log the console  output in stdout.log
 QEMU_CONSOLE_LOG=`pwd`/stdout.log


### PR DESCRIPTION
Using 'virtio-rng-pci' would register a device controlled by the HV
as a source of entropy. Since the SEV attacker model considers the HV
as untrusted, the Guest should not rely on the HV to add entropy to
its entropy pool.
This shouldn't necessarily be a security risk since the Guest receives
entropy from other sources as well but it would be good to address this.
The device must have been added to the script by mistake consindering
the comment discusses the virtio ring while the device name is virtio
rng.