### PR TITLE
Activate CONFIG_X86_CPUID

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -36,6 +36,7 @@ build_kernel()
 		run_cmd ./scripts/config --disable LOCALVERSION_AUTO
 		run_cmd ./scripts/config --enable  AMD_MEM_ENCRYPT
 		run_cmd ./scripts/config --enable  AMD_MEM_ENCRYPT_ACTIVE_BY_DEFAULT
+		run_cmd ./scripts/config --enable  CONFIG_X86_CPUID
 	popd >/dev/null
 
 	run_cmd $MAKE olddefconfig


### PR DESCRIPTION
Ensure that  `CONFIG_X86_CPUID` is activated in the kernel config. This enables `/dev/cpu/*/cpuid`, which is required by `launch-qemu.sh`