### PR TITLE
Disable virtio-rng and virtio-crypto for the guest kernel

### DIFF
--- a/distros/common.sh
+++ b/distros/common.sh
@@ -33,6 +33,8 @@ build_kernel()
 	./scripts/config --module CRYPTO_DEV_CCP_DD
 	./scripts/config --enable CONFIG_CRYPTO_DEV_CCP
 	./scripts/config --disable CONFIG_LOCALVERSION_AUTO
+	./scripts/config --disable CONFIG_HW_RANDOM_VIRTIO
+	./scripts/config --disable CONFIG_CRYPTO_DEV_VIRTIO
 	yes "" | make olddefconfig
 
 	run_cmd "make -j `getconf _NPROCESSORS_ONLN` bindeb-pkg LOCALVERSION=-sev"


### PR DESCRIPTION
VirtioRNG allows the host to inject random data into the /dev/hwrng
device in the guest which is undesirable. Thus, we disable it in the
guest's build script.
Using VirtioCrypto would expose AES cryptographic operations, both keys
and data, so we disable it as well.
This patch disables them also for the host in case this build script is
used for the host kernel. However, this should not be an issue since
the virtio drivers are only used by the guest.