### PR TITLE
gitignore: Add the generated dirs to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 distros/ubuntu-18.04/src
 distros/fedora-28/src
+linux/
+ovmf/
+qemu/
+usr/


### PR DESCRIPTION
When one runs `build.sh` multiple directories are created, so add them to the gitignore list.