### PR TITLE
Fixed 2 issues pertaining to building SNP on Fedora 38

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ if [[ "$BUILD_PACKAGE" = "1" ]]; then
 		cp linux/linux-*-guest-*.deb $OUTPUT_DIR/linux/guest -v
 		cp linux/linux-*-host-*.deb $OUTPUT_DIR/linux/host -v
 	else
-		cp kernel-*.rpm $OUTPUT_DIR/linux -v
+		cp linux/kernel-*.rpm $OUTPUT_DIR/linux -v
 	fi
 
 	cp launch-qemu.sh ${OUTPUT_DIR} -v

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ fi
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then
 	dpkg -i linux/host/linux-image-*.deb
 else
-	rpm -ivh linux/kernel-*.rpm
+	dnf install linux/kernel-*.rpm
 fi
 
 cp kvm.conf /etc/modprobe.d/


### PR DESCRIPTION
1. During installation kernel rpms were missing and were not getting installed.
2. kernel-headers package could not be force installed using rpm.