### PR TITLE
common.sh: Change to the proper directory before adding remote

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -137,7 +137,9 @@ build_install_ovmf()
 		popd >/dev/null
 	else
 		run_cmd git clone --single-branch -b ${OVMF_BRANCH} ${OVMF_GIT_URL} ovmf
+		pushd ovmf >/dev/null
 		run_cmd git remote add current ${OVMF_GIT_URL}
+		popd >/dev/null
 	fi
 
 	pushd ovmf >/dev/null
@@ -169,7 +171,9 @@ build_install_qemu()
 		popd >/dev/null
 	else
 		run_cmd git clone --single-branch -b ${QEMU_BRANCH} ${QEMU_GIT_URL} qemu
+		pushd qemu >/dev/null
 		run_cmd git remote add current ${QEMU_GIT_URL}
+		popd >/dev/null
 	fi
 
 	MAKE="make -j $(getconf _NPROCESSORS_ONLN) LOCALVERSION="


### PR DESCRIPTION
I noticed that the script fails at its first run due to the lack of changing directory before adding remote repository of QEMU and OVMF.
The script seems to intend adding "current" remote repository for both qemu and ovmf, thus It must add remote repository after changing to each directory.
This pull request will fix the problem mentioned above.