### PR TITLE
Fedora & RHEL snp latest fixes for build package and installation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,7 +86,11 @@ if [[ "$BUILD_PACKAGE" = "1" ]]; then
 		cp linux/linux-*-guest-*.deb $OUTPUT_DIR/linux/guest -v
 		cp linux/linux-*-host-*.deb $OUTPUT_DIR/linux/host -v
 	else
-		cp linux/kernel-*.rpm $OUTPUT_DIR/linux -v
+	         #RHEL and Fedora	
+		#cp linux/kernel-*.rpm $OUTPUT_DIR/linux -v
+		cp linux/kernel-*host*.rpm $OUTPUT_DIR/linux/host -v
+		cp linux/kernel-*guest*.rpm $OUTPUT_DIR/linux/guest -v
+		
 	fi
 
 	cp launch-qemu.sh ${OUTPUT_DIR} -v

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then
 	apt-get -y install qemu ovmf
 else
-	dnf install @virt edk2-ovmf -y
+	dnf install qemu-kvm edk2-ovmf -y
 fi
 
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then


### PR DESCRIPTION
1.Fedora & RHEL Virtualization Package(qemu) Fix in install.sh: 
    Replaced virt group package with qemu-kvm package as virt group package is not present in latest Fedora (Fedora 38 and above) and RHEL 9 

2. Fix for copy SNP Kernel (Host&Guest) packages into Separate folders for Non-Debian linux distribution in build.sh